### PR TITLE
Implement routines template selection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -435,9 +435,9 @@ export default function AnchoredApp() {
                 <div style={{ fontWeight: 700, fontSize: '1.05em', color: '#2D3748', marginBottom: '8px' }}>
                   {currentRoutineSummary?.mode ? (
                     <>
-                      {currentRoutineSummary.mode === 'regular' && '🟢 Regular'}
-                      {currentRoutineSummary.mode === 'hard' && '🟡 Hard'}
-                      {currentRoutineSummary.mode === 'hardest' && '🔴 Hardest'}
+                      {currentRoutineSummary.mode === 'regular' && (getCustodyInfo().hasKids ? '🟢 Regular' : '🟢 Regular Solo')}
+                      {currentRoutineSummary.mode === 'hard' && (getCustodyInfo().hasKids ? '🟡 Hard' : '🟡 Recovery')}
+                      {currentRoutineSummary.mode === 'hardest' && (getCustodyInfo().hasKids ? '🔴 Hardest' : '🔴 Hustle')}
                     </>
                   ) : 'No routine set'}
                 </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1191,6 +1191,42 @@ function SituationCard({ icon: Icon, title, subtitle, onClick }) {
 }
 
 function ResponseView({ script, responseStyle, situation, energy, currentRoutineSummary, setEnergy }) {
+  /**
+   * Helper to get custody info (used for solo week mode detection)
+   */
+  const getCustodyInfo = () => {
+    try {
+      const custodySettings = JSON.parse(localStorage.getItem('custodySettings') || '{}');
+      
+      if (!custodySettings.custodyType || custodySettings.custodyType === 'no') {
+        return { hasKids: true };
+      }
+      
+      if (custodySettings.custodyType === 'alternating') {
+        const today = new Date();
+        const referenceWeekStart = new Date(custodySettings.weekStartDate);
+        const getMonday = (date = new Date()) => {
+          const d = new Date(date);
+          const day = d.getDay();
+          const diff = (day + 6) % 7;
+          d.setDate(d.getDate() - diff);
+          return d;
+        };
+        const currentWeekMonday = getMonday(today);
+        const msPerWeek = 7 * 24 * 60 * 60 * 1000;
+        const weeksDiff = Math.floor((currentWeekMonday - referenceWeekStart) / msPerWeek);
+        const hasKids = custodySettings.currentWeekHasKids ? 
+          (weeksDiff % 2 === 0) : 
+          (weeksDiff % 2 === 1);
+        return { hasKids };
+      }
+      
+      return { hasKids: true };
+    } catch (e) {
+      return { hasKids: true };
+    }
+  };
+
   if (!script) {
     return (
       <div style={{
@@ -1443,10 +1479,12 @@ function ResponseView({ script, responseStyle, situation, energy, currentRoutine
           marginBottom: '16px'
         }}>
           <div style={{ fontWeight: 700, color: '#92400E', marginBottom: '8px', fontSize: '0.9em' }}>
-            🟡 You're in Hard Mode
+            🟡 {getCustodyInfo().hasKids ? "You're in Hard Mode" : "You're in Recovery Mode"}
           </div>
           <div style={{ color: '#B45309', fontSize: '0.95em', lineHeight: 1.5 }}>
-            Expectations are lower this week. If you can't follow through perfectly today, that's okay.
+            {getCustodyInfo().hasKids 
+              ? "Expectations are lower this week. If you can't follow through perfectly today, that's okay."
+              : "Extra rest this week. Bed by 10pm, minimal obligations. Meal prep optional - rest is priority."}
           </div>
         </div>
       )}
@@ -1461,10 +1499,12 @@ function ResponseView({ script, responseStyle, situation, energy, currentRoutine
           marginBottom: '16px'
         }}>
           <div style={{ fontWeight: 700, color: '#991B1B', marginBottom: '8px', fontSize: '0.9em' }}>
-            🔴 You're in Survival Mode
+            🔴 {getCustodyInfo().hasKids ? "You're in Survival Mode" : "You're in Hustle Mode"}
           </div>
           <div style={{ color: '#DC2626', fontSize: '0.95em', lineHeight: 1.5 }}>
-            The only goal is everyone alive and fed. If this situation feels impossible right now, it's okay to just survive it. You're doing great.
+            {getCustodyInfo().hasKids
+              ? "The only goal is everyone alive and fed. If this situation feels impossible right now, it's okay to just survive it. You're doing great."
+              : "High prep week! Batch cooking 5-7 meals, organizing, getting ready for tough kids week ahead. You've got this!"}
           </div>
         </div>
       )}

--- a/src/components/RoutinesHome.js
+++ b/src/components/RoutinesHome.js
@@ -95,9 +95,9 @@ export default function RoutinesHome({ onNavigate }) {
     } else {
       // Solo week modes
       const soloModesMap = {
-        regular: { emoji: '🟢', name: 'Regular Solo', desc: 'Balanced recovery and prep week' },
-        hard: { emoji: '🟡', name: 'Recovery', desc: "You're in Recovery Mode. Extra rest this week. Sleep in, take it easy, no guilt." },
-        hardest: { emoji: '🔴', name: 'Hustle', desc: "You're in Hustle Mode. Prepping hard for next kids week. Batch cooking, organizing, getting ahead!" }
+        regular: { emoji: '🟢', name: 'Regular Solo', desc: 'Balanced recovery and prep week. Work, meal prep 2-3 dishes, creative time, rest.' },
+        hard: { emoji: '🟡', name: 'Recovery', desc: "You're in Recovery Mode. Extra rest this week. Bed by 10pm, minimal obligations, meal prep optional." },
+        hardest: { emoji: '🔴', name: 'Hustle', desc: "You're in Hustle Mode. High prep week - batch cooking 5-7 meals, organizing, getting ready for tough kids week!" }
       };
       return soloModesMap[mode] || soloModesMap.regular;
     }

--- a/src/components/RoutinesHome.js
+++ b/src/components/RoutinesHome.js
@@ -80,12 +80,30 @@ export default function RoutinesHome({ onNavigate }) {
 
   const custodyInfo = getCustodyInfo();
 
-  const modeInfoMap = {
-    regular: { emoji: '🟢', name: 'Regular', desc: 'Normal routine mode' },
-    hard: { emoji: '🟡', name: 'Hard', desc: "You're in Hard Mode. Screens unlimited, easy meals fine, homework optional. This is smart adaptation." },
-    hardest: { emoji: '🔴', name: 'Hardest', desc: "You're in Survival Mode. Only goal: everyone alive and fed. You're doing GREAT." }
+  /**
+   * Get mode information based on mode and whether kids are present
+   */
+  const getModeInfo = (mode, hasKids) => {
+    if (hasKids) {
+      // Kids week modes
+      const kidsModesMap = {
+        regular: { emoji: '🟢', name: 'Regular', desc: 'Normal routine mode' },
+        hard: { emoji: '🟡', name: 'Hard', desc: "You're in Hard Mode. Screens unlimited, easy meals fine, homework optional. This is smart adaptation." },
+        hardest: { emoji: '🔴', name: 'Hardest', desc: "You're in Survival Mode. Only goal: everyone alive and fed. You're doing GREAT." }
+      };
+      return kidsModesMap[mode] || kidsModesMap.regular;
+    } else {
+      // Solo week modes
+      const soloModesMap = {
+        regular: { emoji: '🟢', name: 'Regular Solo', desc: 'Balanced recovery and prep week' },
+        hard: { emoji: '🟡', name: 'Recovery', desc: "You're in Recovery Mode. Extra rest this week. Sleep in, take it easy, no guilt." },
+        hardest: { emoji: '🔴', name: 'Hustle', desc: "You're in Hustle Mode. Prepping hard for next kids week. Batch cooking, organizing, getting ahead!" }
+      };
+      return soloModesMap[mode] || soloModesMap.regular;
+    }
   };
-  const modeInfo = modeInfoMap[mode] || modeInfoMap.regular;
+
+  const modeInfo = getModeInfo(mode, custodyInfo.hasKids);
 
   const borderGradient = mode === 'regular' ? '#6BCB77' : mode === 'hard' ? '#FFD93D' : '#FF6B6B';
 
@@ -141,14 +159,14 @@ export default function RoutinesHome({ onNavigate }) {
           boxShadow: '0 2px 8px rgba(0,0,0,0.04)'
         }}>
           <div style={{ marginBottom: '8px', color: '#2D3748', fontWeight: 700, fontSize: '18px' }}>
-            {custodyInfo.hasKids ? '👨‍👩‍👧‍👦 Kids with you this week' : '🏠 Kids at dad\'s this week'}
+            {custodyInfo.hasKids ? '👨‍👩‍👧‍👦 Kids with you this week' : '🏖️ Solo week - time for you'}
           </div>
           <div style={{ color: '#6B7280', marginBottom: '16px', fontSize: '14px' }}>
             {custodyInfo.hasKids ? 
               'Create a routine for the week ahead' : 
-              'Plan your solo time this week'}
+              'Plan your recovery and prep time'}
           </div>
-          {custodyInfo.handover && (
+          {custodyInfo.handover && custodyInfo.hasKids && (
             <div style={{ color: '#9A938E', marginBottom: '16px', fontSize: '13px', fontStyle: 'italic' }}>
               {custodyInfo.handover}
             </div>
@@ -166,7 +184,7 @@ export default function RoutinesHome({ onNavigate }) {
               cursor: 'pointer'
             }}
           >
-            {custodyInfo.hasKids ? 'Create Routine' : 'Plan Week'}
+            {custodyInfo.hasKids ? 'Create Kids Week Routine' : 'Create Solo Week Routine'}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
Updated all three solo week templates with real tasks:
Regular Solo: Work schedule (remote Mon/Fri, commute Tue/Wed/Thu), meal prep 2-3 dishes, creative time, decompression
Recovery Solo: Same structure with rest focus (bed by 10pm, minimal obligations, meal prep optional)
Hustle Solo: High prep mode (meal prep 5-7 dishes, organizing, move planning)
Updated RoutinesHome mode descriptions:
Regular Solo: "Balanced recovery and prep week. Work, meal prep 2-3 dishes, creative time, rest."
Recovery: "Extra rest this week. Bed by 10pm, minimal obligations, meal prep optional."
Hustle: "High prep week - batch cooking 5-7 meals, organizing, getting ready for tough kids week!"
Updated App.js context boxes:
Hard Mode context box shows "Recovery Mode" for solo weeks
Hardest Mode context box shows "Hustle Mode" for solo weeks
Descriptions adjust based on kids presence
Build passes with no errors. The solo week templates now reflect your actual schedule (work, commute days, meal prep targets, creative time). Ready to use.


## Type
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 💅 Refactor / Cleanup
- [ ] 🧰 Config / CI
- [ ] 📝 Docs

## Testing & Validation
✅ Local lint/build/tests pass  
🧪 Manual verification (describe briefly or attach screenshot)  

## Impact / Risk (optional)
Medium

## Notes (optional)

